### PR TITLE
Clarify API key comment and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Santic Barber
+
+Este proyecto utiliza Firebase para gestionar datos y analíticas. La clave de API incluida en el código es pública y no es un secreto en sí, pero es recomendable restringir su uso desde la consola de Firebase.
+
+## Restringir la clave de API
+
+1. Inicia sesión en [Firebase Console](https://console.firebase.google.com/).
+2. Selecciona el proyecto **santicbarber**.
+3. Entra en **Project settings** y busca la sección **Your apps**.
+4. Localiza la **Firebase Web API Key** y abre las opciones de configuración.
+5. Define restricciones de uso (por ejemplo, dominios permitidos) para evitar abusos.
+6. Guarda los cambios.
+
+## Configuración en producción
+
+Para entornos de producción se recomienda mover esta configuración a un archivo separado o utilizar variables de entorno que se carguen al momento del despliegue.

--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@
 
       // Your web app's Firebase configuration
       const firebaseConfig = {
-        apiKey: "AIzaSyBHaT9gQRq1e58VjX798LnkxqLtjF9W9DA", // KEEP YOUR KEY SECRET
+        apiKey: "AIzaSyBHaT9gQRq1e58VjX798LnkxqLtjF9W9DA", // Public API key - restrict usage in Firebase console
         authDomain: "santicbarber.firebaseapp.com",
         databaseURL: "https://santicbarber-default-rtdb.firebaseio.com",
         projectId: "santicbarber",


### PR DESCRIPTION
## Summary
- clarify the firebase API key comment in `index.html`
- add `README.md` with instructions on restricting the API key and a note about using environment variables in production

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840c3a9185c8320b8bdd03a21a396ba